### PR TITLE
Block placing fix and .gitignore change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,12 @@ local.properties
 *.war
 *.ear
 
+### Server ###
+diorite.yml
+worlds/
+plugins/
+lang/
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/diorite-core/src/main/java/org/diorite/impl/pipelines/event/player/BlockPlacePipelineImpl.java
+++ b/diorite-core/src/main/java/org/diorite/impl/pipelines/event/player/BlockPlacePipelineImpl.java
@@ -24,9 +24,9 @@
 
 package org.diorite.impl.pipelines.event.player;
 
-import org.diorite.GameMode;
 import org.diorite.impl.DioriteCore;
 import org.diorite.impl.connection.packets.play.clientbound.PacketPlayClientboundBlockChange;
+import org.diorite.GameMode;
 import org.diorite.event.pipelines.event.player.BlockPlacePipeline;
 import org.diorite.event.player.PlayerBlockPlaceEvent;
 import org.diorite.inventory.item.ItemStack;

--- a/diorite/src/main/java/org/diorite/impl/server/connection/listeners/PlayListener.java
+++ b/diorite/src/main/java/org/diorite/impl/server/connection/listeners/PlayListener.java
@@ -89,7 +89,6 @@ public class PlayListener implements PacketPlayServerboundListener
         this.player = player;
     }
 
-
     @Override
     public void handle(final PacketPlayServerboundKeepAlive packet)
     {
@@ -310,14 +309,13 @@ public class PlayListener implements PacketPlayServerboundListener
         }
         this.core.sync(() -> EventType.callEvent(new PlayerInteractEvent(this.player, Action.RIGHT_CLICK_ON_BLOCK, packet.getLocation().setWorld(this.player.getWorld()).getBlock())));
 
+        final PlayerBlockPlaceEvent event = new PlayerBlockPlaceEvent(this.player, packet.getLocation().setWorld(this.player.getWorld()).getBlock().getRelative(packet.getCursorPos().getBlockFace()));
         final int y = packet.getLocation().getY() + packet.getCursorPos().getBlockFace().getModY();
         if ((y >= Chunk.CHUNK_FULL_HEIGHT) || (y < 0))
         {
-            return; // TODO: some kind of event for that maybe? or edit PlayerBlockPlaceEvent
+            event.setCancelled(true);
         }
-
-        final PlayerBlockPlaceEvent event = new PlayerBlockPlaceEvent(this.player, packet.getLocation().setWorld(this.player.getWorld()).getBlock().getRelative(packet.getCursorPos().getBlockFace()));
-        if (this.player.getInventory().getItem(this.player.getHeldItemSlot()).getAmount() < 1)
+        else if (this.player.getInventory().getItemInHand() == null || this.player.getInventory().getItemInHand().getAmount() < 1)
         {
             event.setCancelled(true);
         }


### PR DESCRIPTION
1. Fixed problem with disconnecting when placing block without any item
   in hand.
2. When block is placed above chunk or under 0 y-level cancelled event
   is send.
3. Changed .gitignore so now you can easily run server and don't have to
   remove diorite generated files from commit

Previous commit wasn't working as expected. It was my fault, I am sorry for that. The bug leading to disconnecting players every time they wanted to place anything is now fixed. Also I fixed some bug which existed before my last commit. That bug disconnected players if they were trying to place `null`.
